### PR TITLE
Use of 'props' in Constructor

### DIFF
--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -4,6 +4,7 @@ import FunctionComponent from './components/FunctionComponent';
 import PropsInComponent from './components/PropsInComponent';
 import ComponentInComponent from './components/ComponentInComponent';
 import ConstructorInComponent from './components/ConstructorInComponent';
+import PropsInConstructor from './components/PropsInConstructor';
 
 function App() {
   return (
@@ -13,6 +14,7 @@ function App() {
       <PropsInComponent property="World" />
       <ComponentInComponent />
       <ConstructorInComponent />
+      <PropsInConstructor property="World" />
     </div>
   );
 }

--- a/my-app/src/components/PropsInConstructor.js
+++ b/my-app/src/components/PropsInConstructor.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+class PropsInConstructor extends React.Component {
+    constructor(props) {
+        super(props);
+    }
+
+    render() {
+        return <h1>I have a Constructor. It received Property = {this.props.property} for me.</h1>
+    }
+}
+
+export default PropsInConstructor;


### PR DESCRIPTION
Use of 'props' in Constructor

- If React Component has a Constructor, the props should always be passed to the Constructor and also to the React.Component via the super() method.