### PR TITLE
Use of built-in methods for Mounting Phase of a Component

### DIFF
--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -6,6 +6,7 @@ import ComponentInComponent from './components/ComponentInComponent';
 import ConstructorInComponent from './components/ConstructorInComponent';
 import PropsInConstructor from './components/PropsInConstructor';
 import StateObjectInConstructor from './components/StateObjectInConstructor';
+import MountingPhaseComponentMethods from './components/MountingPhaseComponentMethods';
 
 function App() {
   return (
@@ -17,6 +18,7 @@ function App() {
       <ConstructorInComponent />
       <PropsInConstructor property="World" />
       <StateObjectInConstructor />
+      <MountingPhaseComponentMethods property="Set using 'getDerivedStateFromProps()' method" />
     </div>
   );
 }

--- a/my-app/src/components/MountingPhaseComponentMethods.js
+++ b/my-app/src/components/MountingPhaseComponentMethods.js
@@ -1,0 +1,36 @@
+import React from 'react';
+
+class MountingPhaseComponentMethods extends React.Component {
+    constructor(props) {
+        super(props);
+        // Initialize state with derivedProperty and a flag (updatedByComponentDidMount) to track if componentDidMount has updated the state.
+        this.state = {
+            derivedProperty: "Set in constructor() method",
+            updatedByComponentDidMount: false
+        };
+    }
+
+    // This method is called every time the component receives new props.
+    static getDerivedStateFromProps(props, state) {
+        // Only update state if it has not been updated by componentDidMount
+        if (!state.updatedByComponentDidMount) {
+            return {derivedProperty: props.property};
+        }
+        return null; // No state update
+    }
+
+    componentDidMount() {
+        setTimeout(() => {
+            this.setState({
+                derivedProperty: "Set in componentDidMount() method",
+                updatedByComponentDidMount: true
+            })
+        }, 3000)
+    }
+
+    render() {
+        return <h1>I have one Property in State Object:- Property = {this.state.derivedProperty}.</h1>
+    }
+}
+
+export default MountingPhaseComponentMethods;


### PR DESCRIPTION
Use of built-in methods for Mounting Phase of a Component

- React Component has 3 main phases of its Lifecycle: (1.) Mounting, (2.) Updating, (3.) Unmounting
- We have 4 built-in methods that get called in Mounting Phase:

1. constructor(): This method is called before anything else, when the component is initiated.

2. getDerivedStateFromProps(): This method is called right before rendering the elements in DOM. This is the natural place to set the state object based on the initial props. It takes state as an argument, and returns an object with changes to the state.

3. render(): This method is required. It must be used. It outputs HTML to DOM.

4. componentDidMount(): It is called after the component is rendered.